### PR TITLE
Bump Go version to 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ go:
     - 1.9.x
     - 1.10.x
     - 1.11.x
+    - 1.12.x
     - master
 env:
     matrix:
@@ -28,9 +29,9 @@ matrix:
     include:
         - go: 1.11.x
           env: MODE=gopherjs
-        - go: 1.11.x
+        - go: 1.12.x
           env: MODE=linter
-        - go: 1.11.x
+        - go: 1.12.x
           env: MODE=coverage
 
 install:


### PR DESCRIPTION
Except for GopherJS, which isn't quite ready yet